### PR TITLE
Added toContainersGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ main = do
   print (GraphML_P.parse file)
 ```
 
-## Graph support  
+## Graph File support  
 ### [GraphML](http://graphml.graphdrawing.org/)
 GraphML files are currently:  
 - Parsing: Ok  
@@ -67,3 +67,9 @@ GraphML files are currently:
 Workcraft files are currently:  
 - Parsing: **Unimplemented**  
 - Writing: **Unimplemented**
+
+## Graph Library support  
+### [Containers](https://hackage.haskell.org/package/containers)
+Currently implements:  
+- FromPangraph: **Implmented**
+- ToPangraph:   **Unimplemented**

--- a/pangraph.cabal
+++ b/pangraph.cabal
@@ -23,7 +23,7 @@ library
                    ,  Pangraph.VHDL.Internal.GraphWriter
                    ,  Pangraph.VHDL.Internal.EnvironmentWriter
                    ,  Pangraph.Internal.XMLTemplate
-  other-modules:      Pangraph.Examples.Reading
+                   ,  Pangraph.Examples.Reading
                    ,  Pangraph.Examples.Writing
                    ,  Pangraph.Examples.ToContainersGraph
                    ,  Pangraph.Examples.SampleGraph
@@ -43,10 +43,12 @@ test-suite pangraph-test
                    ,  GraphML
                    ,  VHDL
                    ,  VHDLLiterals
+                   ,  Containers
   build-depends:      base >= 4.8 && < 5
                    ,  pangraph
                    ,  bytestring
                    ,  HUnit
+                   ,  containers
   default-language:   Haskell2010
   GHC-options:        -Wall -fwarn-tabs -fbreak-on-exception
 

--- a/pangraph.cabal
+++ b/pangraph.cabal
@@ -26,6 +26,7 @@ library
   other-modules:      Pangraph.Examples.Reading
                    ,  Pangraph.Examples.Writing
                    ,  Pangraph.Examples.ToContainersGraph
+                   ,  Pangraph.Examples.SampleGraph
   build-depends:      base >= 4.8 && < 5
                    ,  bytestring
                    ,  hexml

--- a/pangraph.cabal
+++ b/pangraph.cabal
@@ -16,6 +16,7 @@ tested-with:          GHC==8.0.2
 library
   hs-source-dirs:     src
   exposed-modules:    Pangraph
+                   ,  Pangraph.Containers
                    ,  Pangraph.GraphML.Parser
                    ,  Pangraph.GraphML.Writer
                    ,  Pangraph.VHDL.Writer
@@ -24,6 +25,7 @@ library
                    ,  Pangraph.Internal.XMLTemplate
   other-modules:      Pangraph.Examples.Reading
                    ,  Pangraph.Examples.Writing
+                   ,  Pangraph.Examples.ToContainersGraph
   build-depends:      base >= 4.8 && < 5
                    ,  bytestring
                    ,  hexml

--- a/src/Pangraph.hs
+++ b/src/Pangraph.hs
@@ -14,13 +14,12 @@ module Pangraph (
 
     -- * Getters on Vertex and Edge
     edgeAttributes, vertexAttributes,
-    edgeEndpoints, edgeEndpointIDs, edgeID, vertexID
+    edgeEndpoints, edgeID, vertexID
 
 ) where
 
 import Data.Maybe            (mapMaybe)
 import Data.Map.Strict       (Map)
-import Control.Arrow         ((***))
 import qualified Data.Map.Strict  as Map
 import qualified Data.ByteString  as BS
 import qualified Algebra.Graph.Class as Alga
@@ -133,10 +132,6 @@ vertexAttributes = vertexAttributes'
 -- | Returns the endpoint of tupled 'Vertex' of an 'Edge'
 edgeEndpoints :: Edge -> (Vertex, Vertex)
 edgeEndpoints = endpoints'
-
--- | Like 'edgeEndpoints' but returns the 'VertexID's instead.
-edgeEndpointIDs :: Edge -> (VertexID, VertexID)
-edgeEndpointIDs e = (vertexID *** vertexID) $ edgeEndpoints e
 
 -- | Returns the EdgeID if it has one. 'Edge's are given a new 'EdgeID' when they are passed and retrived from a 'Pangraph'
 edgeID :: Edge -> Maybe EdgeID

--- a/src/Pangraph.hs
+++ b/src/Pangraph.hs
@@ -20,6 +20,7 @@ module Pangraph (
 
 import Data.Maybe            (mapMaybe)
 import Data.Map.Strict       (Map)
+import Control.Arrow         ((***))
 import qualified Data.Map.Strict  as Map
 import qualified Data.ByteString  as BS
 import qualified Algebra.Graph.Class as Alga
@@ -135,7 +136,7 @@ edgeEndpoints = endpoints'
 
 -- | Like 'edgeEndpoints' but returns the 'VertexID's instead.
 edgeEndpointIDs :: Edge -> (VertexID, VertexID)
-edgeEndpointIDs = (vertexID Control.Arrow.*** vertexID) edgeEndpoints  
+edgeEndpointIDs e = (vertexID *** vertexID) $ edgeEndpoints e
 
 -- | Returns the EdgeID if it has one. 'Edge's are given a new 'EdgeID' when they are passed and retrived from a 'Pangraph'
 edgeID :: Edge -> Maybe EdgeID

--- a/src/Pangraph.hs
+++ b/src/Pangraph.hs
@@ -14,7 +14,7 @@ module Pangraph (
 
     -- * Getters on Vertex and Edge
     edgeAttributes, vertexAttributes,
-    edgeEndpoints, edgeID, vertexID
+    edgeEndpoints, edgeEndpointIDs, edgeID, vertexID
 
 ) where
 
@@ -132,6 +132,10 @@ vertexAttributes = vertexAttributes'
 -- | Returns the endpoint of tupled 'Vertex' of an 'Edge'
 edgeEndpoints :: Edge -> (Vertex, Vertex)
 edgeEndpoints = endpoints'
+
+-- | Like 'edgeEndpoints' but returns the 'VertexID's instead.
+edgeEndpointIDs :: Edge -> (VertexID, VertexID)
+edgeEndpointIDs = (vertexID Control.Arrow.*** vertexID) edgeEndpoints  
 
 -- | Returns the EdgeID if it has one. 'Edge's are given a new 'EdgeID' when they are passed and retrived from a 'Pangraph'
 edgeID :: Edge -> Maybe EdgeID

--- a/src/Pangraph/Containers.hs
+++ b/src/Pangraph/Containers.hs
@@ -1,0 +1,35 @@
+module Pangraph.Containers
+    (  toContainerGraph
+    )
+    where
+
+import Pangraph
+import qualified Data.Graph as CGraph
+
+import Data.Map.Strict(Map)
+import qualified Data.Map.Strict as Map
+
+-- | Transforms a 'Pangraph' in a 'CGraph.Graph'.
+toContainerGraph :: Pangraph -> (CGraph.Graph, CGraph.Vertex -> (Vertex, VertexID, [VertexID]), VertexID -> Maybe CGraph.Vertex)
+toContainerGraph p = CGraph.graphFromEdges getVertices
+  where
+    -- Create the an Edge Map using VertexID grouping edge sources together.
+    edgeMap :: Map VertexID [VertexID]
+    edgeMap = (Map.fromList . squashIDs) $ map edgeEndpointIDs $ edgeList p
+
+    -- Lookup the edges for this vertex. Returning empty list on Nothing.
+    vertexConnections :: Vertex -> [VertexID]
+    vertexConnections v = fromMaybe [] (Map.lookup (vertexID v) edgeMap)
+
+
+    -- Convert Pangraph Vertex into a form ready to collect Edges from the Pangraph
+    getVertices :: [(Vertex, VertexID, [VertexID])]
+    getVertices = map (\v ->(v, vertexID v, vertexConnections v)) $ vertexList p
+
+-- A function to group edge endpoints in buckets.
+squashIDs :: [(VertexID, VertexID)] -> [(VertexID, [VertexID])]
+squashIDs as = Map.toList $ accumMap Map.empty as
+  where
+    accumMap :: Map VertexID [VertexID] -> [(VertexID, VertexID)] -> Map VertexID [VertexID]
+    accumMap t [] = t
+    accumMap m (a:c) = accumMap (Map.insertWith (++) (fst a) [snd a] m) c

--- a/src/Pangraph/Containers.hs
+++ b/src/Pangraph/Containers.hs
@@ -6,6 +6,8 @@ module Pangraph.Containers
 import Pangraph
 import qualified Data.Graph as CGraph
 
+import Data.Maybe(fromMaybe)
+
 import Data.Map.Strict(Map)
 import qualified Data.Map.Strict as Map
 
@@ -20,7 +22,6 @@ toContainerGraph p = CGraph.graphFromEdges getVertices
     -- Lookup the edges for this vertex. Returning empty list on Nothing.
     vertexConnections :: Vertex -> [VertexID]
     vertexConnections v = fromMaybe [] (Map.lookup (vertexID v) edgeMap)
-
 
     -- Convert Pangraph Vertex into a form ready to collect Edges from the Pangraph
     getVertices :: [(Vertex, VertexID, [VertexID])]

--- a/src/Pangraph/Examples/SampleGraph.hs
+++ b/src/Pangraph/Examples/SampleGraph.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Pangraph.Examples.SampleGraph
+    ( smallGraph
+    ) where
+
+import Pangraph
+
+smallGraph :: Pangraph
+smallGraph = case graph of
+  Just p  -> p
+  Nothing -> error "Small graph literal failed to construct."
+  where
+    graph =
+      makePangraph
+        [makeVertex "n0" [("id","n0")]
+        ,makeVertex "n1" [("id","n1")]
+        ,makeVertex "n2" [("id","n2")]]
+        [makeEdge [("source","n0"),("target","n2")]
+          (makeVertex "n0" [("id","n0")]
+          ,makeVertex "n2" [("id","n2")])]

--- a/src/Pangraph/Examples/ToContainersGraph.hs
+++ b/src/Pangraph/Examples/ToContainersGraph.hs
@@ -1,18 +1,9 @@
 module Pangraph.Examples.ToContainersGraph where
 
-import Prelude hiding (readFile)
-
-import Data.ByteString (readFile)
-
-import qualified Pangraph.GraphML.Parser as GraphML
-import qualified Pangraph.Containers as CGraph
+import Pangraph.Containers(convert)
+import Pangraph.Examples.SampleGraph(smallGraph)
 
 main :: IO ()
-main = do
-  fileName <- getLine
-  -- Read the files as ByteString
-  file <- readFile fileName
-  -- Transform to Pangraph and print
-  let pangraph = GraphML.unsafeParse file
+main =
   -- Transform to Containers Data.Graph and print.
-  print $ ((\(a,_,_) -> a) . CGraph.toContainerGraph) pangraph
+  print $ ((\(a,_,_) -> a) . convert) smallGraph

--- a/src/Pangraph/Examples/ToContainersGraph.hs
+++ b/src/Pangraph/Examples/ToContainersGraph.hs
@@ -1,0 +1,18 @@
+module Pangraph.Examples.ToContainersGraph where
+
+import Prelude hiding (readFile)
+
+import Data.ByteString (readFile)
+
+import qualified Pangraph.GraphML.Parser as GraphML
+import qualified Pangraph.Containers as CGraph
+
+main :: IO ()
+main = do
+  fileName <- getLine
+  -- Read the files as ByteString
+  file <- readFile fileName
+  -- Transform to Pangraph and print
+  let pangraph = GraphML.unsafeParse file
+  -- Transform to Containers Data.Graph and print.
+  print $ ((\(a,_,_) -> a) . CGraph.toContainerGraph) pangraph

--- a/src/Pangraph/Examples/Writing.hs
+++ b/src/Pangraph/Examples/Writing.hs
@@ -1,14 +1,10 @@
 module Pangraph.Examples.Writing where
 
-import Prelude hiding (readFile)
-
-import Data.ByteString (readFile)
-
-import qualified Pangraph.GraphML.Parser as GraphML
-import qualified Pangraph.GraphML.Writer as GraphML
+import Pangraph.GraphML.Writer(write)
+import Pangraph.Examples.SampleGraph(smallGraph)
 
 main :: IO ()
-main = do
-  fileName <- getLine
-  file <- readFile fileName
-  print $ GraphML.write (GraphML.unsafeParse file)
+main =
+  -- >>> :t write
+  -- write :: Pangraph.Pangraph -> Data.ByteString.Internal.ByteString
+  print $ write smallGraph

--- a/test/Containers.hs
+++ b/test/Containers.hs
@@ -1,0 +1,13 @@
+module Containers
+    ( containersTests
+    ) where
+
+import Test.HUnit
+import Pangraph.Examples.SampleGraph(smallGraph)
+import Pangraph.Containers(convert)
+
+containersTests :: [Test]
+containersTests = [case1]
+
+case1 :: Test
+case1 = TestCase $ assertEqual "Containers Convert case 1" ("array (0,2) [(0,[2]),(1,[]),(2,[])]") $ (show . (\(a,_,_) -> a) . convert) smallGraph

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,8 +3,9 @@ module Main where
 import GraphML
 import Show
 import VHDL
+import Containers
 
 import Test.HUnit
 
 main :: IO Counts
-main = runTestTT $ TestList $ concat [graphmlTests, showTests, vhdlTests]
+main = runTestTT $ TestList $ concat [graphmlTests, showTests, vhdlTests, containersTests]


### PR DESCRIPTION
`Pangraph` now exports `edgeEndpointIDs`

`Pangraph.Containers` implements `ToContainers`

Examples, Haddock and README updated.