### PR TITLE
Update testing for new GHC-8.6.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ before_cache:
 
 matrix:
   include:
+    - compiler: "ghc-8.6.1"
+    # env: TEST=--disable-tests BENCH=--disable-benchmarks
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-head,ghc-8.6.1], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.3"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.2,ghc-8.4.3], sources: [hvr-ghc]}}

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,12 @@
 # Changelog
 
-## pangraph-0.2.1
-* Bump Algebraic Graphs from 0.1.* to 0.2.*
-
 ## pangraph-0.2.0 
+* Bump Algebraic Graphs from 0.1.* to 0.2.*
 * Addition of conversion and revert for FGL.
 * Addition of Parser, Serializer and AST for GML.
 * Change `Edge` types to now only construct with a `VertexID` type.
 * Change `edgeEndpoints` to return VertexID.
+* Add testing with GHC-8.6.1
 
 ## pangraph-0.1.2 141360fbc2b6ca232ce91a9b14aa9a626082ba92 08/06/2018
 Note: First Hackage release which follows correct cabal versioning increments.  

--- a/pangraph.cabal
+++ b/pangraph.cabal
@@ -1,5 +1,5 @@
 name:                 pangraph
-version:              0.2.1
+version:              0.2.0
 synopsis:             A set of parsers for graph languages and conversions to 
                       graph libaries.
 description:          A package allowing parsing of graph files into graph 
@@ -21,7 +21,8 @@ stability:            experimental
 -- Last three major versions
 tested-with:          GHC==8.0.2,
                       GHC==8.2.2,
-                      GHC==8.4.3
+                      GHC==8.4.3,
+                      GHC==8.6.1
 
 library
   hs-source-dirs:     src


### PR DESCRIPTION
Decided to place in 0.2.0 release as it adds no new features and it was not yet on hackage.