### PR TITLE
0.2.0.1 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## pangraph-0.2.1
+## pangraph-0.2.0.1
 * Bump Algebraic Graphs from 0.1.* to 0.2.*
+* Use Cabal for Travis builds (instead of Stack)
+* Move examples into Pangraph.Examples
 
 ## pangraph-0.2.0 
 * Addition of conversion and revert for FGL.

--- a/pangraph.cabal
+++ b/pangraph.cabal
@@ -1,5 +1,5 @@
 name:                 pangraph
-version:              0.2.1
+version:              0.2.0.1
 synopsis:             A set of parsers for graph languages and conversions to 
                       graph libaries.
 description:          A package allowing parsing of graph files into graph 


### PR DESCRIPTION
## pangraph-0.2.0.1
* Bump Algebraic Graphs from 0.1.* to 0.2.*
* Use Cabal for Travis builds (instead of Stack)
* Move examples into `Pangraph.Examples` from `Pangraph.Example.*`