### PR TITLE
Make GraphML.Writer use vertexID and edgeEndpoints

### DIFF
--- a/src/Pangraph/GraphML/Writer.hs
+++ b/src/Pangraph/GraphML/Writer.hs
@@ -37,17 +37,28 @@ writeGraphML _ = "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" \
 writeGraphTag :: Int -> ByteString
 writeGraphTag i = getIndentBS i `append` "<graph id=\"G\" edgedefault=\"undirected\">\n"
 
+mergedVertexAttributes :: Vertex -> [Attribute]
+mergedVertexAttributes v = ("id", vertexID v) : (filter notID $ vertexAttributes v)
+  where
+    notID (key, _) = key /= "id"
+
 writeNode :: Int -> Vertex -> ByteString
 writeNode i v = concat [getIndentBS i, "<node", nodesAtts, "/>\n"]
   where
     nodesAtts :: ByteString
-    nodesAtts = concat $ map writeAttribute (vertexAttributes v)
+    nodesAtts = concat $ map writeAttribute (mergedVertexAttributes v)
+
+mergedEdgeAttributes :: Edge -> [Attribute]
+mergedEdgeAttributes e = ("source", source) : ("target", target) : (filter notEndpoint $ edgeAttributes e)
+  where
+    (source, target) = edgeEndpoints e
+    notEndpoint (key, _) = key /= "source" && key /= "target"
 
 writeEdge :: Int -> Edge -> ByteString
 writeEdge i e = concat [getIndentBS i, "<edge", edgeAtts, "/>\n"]
   where
     edgeAtts :: ByteString
-    edgeAtts = concat $ map writeAttribute (edgeAttributes e)
+    edgeAtts = concat $ map writeAttribute (mergedEdgeAttributes e)
 
 writeAttribute :: Attribute -> ByteString
 writeAttribute (a,b) = concat [" ",  a, "=\"",  b, "\""]

--- a/test/GraphML.hs
+++ b/test/GraphML.hs
@@ -51,12 +51,12 @@ case3 = TestCase $ assertEqual "GraphML Write case: without explicit id attribut
                [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
                  "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n",
                  "  <graph id=\"G\" edgedefault=\"undirected\">\n",
-                 "    <node id=\"foo\"/>\n",
                  "    <node id=\"bar\"/>\n",
                  "    <node id=\"buzz\"/>\n",
+                 "    <node id=\"foo\"/>\n",
                  "    <edge source=\"foo\" target=\"bar\"/>\n",
                  "    <edge source=\"bar\" target=\"buzz\"/>\n",
                  "    <edge source=\"buzz\" target=\"foo\"/>\n",
                  "  </graph>\n",
-                 "</graphml>\n"
+                 "</graphml>"
                ]

--- a/test/GraphML.hs
+++ b/test/GraphML.hs
@@ -12,7 +12,7 @@ import Pangraph.GraphML.Writer
 import Pangraph.Examples.SampleGraph
 
 graphmlTests :: [Test]
-graphmlTests = [case1, case2]
+graphmlTests = [case1, case2, case3]
 
 case1 :: Test
 case1 =
@@ -34,3 +34,29 @@ case1 =
 
 case2 :: Test
 case2 = TestCase $ assertEqual "GraphML Write case 1" (Just smallGraph) (parse . write $ smallGraph)
+
+case3 :: Test
+case3 = TestCase $ assertEqual "GraphML Write case: without explicit id attributes" expected (write input)
+  where
+    (Just input) = makePangraph vertices edges
+    vertices = [ makeVertex "foo" [],
+                 makeVertex "bar" [],
+                 makeVertex "buzz" []
+               ]
+    edges = [ makeEdge ("foo", "bar") [],
+              makeEdge ("bar", "buzz") [],
+              makeEdge ("buzz", "foo") []
+            ]
+    expected = mconcat
+               [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+                 "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n",
+                 "  <graph id=\"G\" edgedefault=\"undirected\">\n",
+                 "    <node id=\"foo\"/>\n",
+                 "    <node id=\"bar\"/>\n",
+                 "    <node id=\"buzz\"/>\n",
+                 "    <edge source=\"foo\" target=\"bar\"/>\n",
+                 "    <edge source=\"bar\" target=\"buzz\"/>\n",
+                 "    <edge source=\"buzz\" target=\"foo\"/>\n",
+                 "  </graph>\n",
+                 "</graphml>\n"
+               ]


### PR DESCRIPTION
Fix for #41.

To keep backward-compatibility, now "id", "source" and "target" attributes stored in Vertex or Edge are ignored. Those attributes in the output are now provided by `vertexID` and `edgeEndpoints`.
